### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The button's intrinsic content size is updated when the button's title changes, 
 
 ## Installation
 
-Simply add `DJWInsetFillButton` to your Podfile if you're using Cocoapods. Alternatively, add `DJWInsetFillButton.h` and `DJWInsetFillButton.m` to your project. Included in this repository is a demo application, showing the project in action.
+Simply add `DJWInsetFillButton` to your Podfile if you're using CocoaPods. Alternatively, add `DJWInsetFillButton.h` and `DJWInsetFillButton.m` to your project. Included in this repository is a demo application, showing the project in action.
 
 ## License
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
